### PR TITLE
Add detection mode

### DIFF
--- a/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
+++ b/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
@@ -52,6 +52,8 @@ class AutoSegmentationModel(object):
         self._define_standard_glyphs()
         self._point_cloud_material = None
         self._contour_material = None
+        self._mesh_material = None
+        self._plane_material = None
         self._define_materials()
 
     def get_context(self):
@@ -127,6 +129,12 @@ class AutoSegmentationModel(object):
     def get_contour_material(self):
         return self._contour_material
 
+    def get_mesh_material(self):
+        return self._mesh_material
+
+    def get_plane_material(self):
+        return self._plane_material
+
     def _define_standard_glyphs(self):
         glyph_module = self._context.getGlyphmodule()
         glyph_module.defineStandardGlyphs()
@@ -136,6 +144,8 @@ class AutoSegmentationModel(object):
         material_module.defineStandardMaterials()
         self._point_cloud_material = material_module.findMaterialByName("yellow")
         self._contour_material = material_module.findMaterialByName("white")
+        self._mesh_material = material_module.findMaterialByName("blue")
+        self._plane_material = material_module.findMaterialByName("green")
 
     def _create_finite_elements(self):
         self._field_module.beginChange()

--- a/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
+++ b/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
@@ -9,6 +9,7 @@ from cmlibs.zinc.field import Field, FieldImage
 
 from cmlibs.utils.zinc.finiteelement import create_cube_element, create_square_element
 from cmlibs.utils.zinc.field import create_field_coordinates, create_field_visibility_for_plane
+from cmlibs.utils.zinc.node import get_field_values
 from cmlibs.utils.zinc.general import ChangeManager
 from cmlibs.utils.geometry.plane import ZincPlane
 
@@ -233,7 +234,6 @@ class AutoSegmentationModel(object):
 
         return mesh_coordinates
 
-    # TODO: Update this so that it is compatible with the Orientation and Translation handlers.
     def _create_detection_plane(self):
         node_coordinate_set = self._define_node_positions()
         point_on_plane = calculate_centroid(node_coordinate_set)
@@ -280,6 +280,12 @@ class AutoSegmentationModel(object):
         reverse_normal = [-component for component in normal]
         self._detection_plane.setNormal(reverse_normal)
 
+    def plane_nodes_coordinates(self):
+        field_module = self._detection_region.getFieldmodule()
+        coordinate_field_name = self._detection_coordinates.getName()
+        coordinate_field = field_module.findFieldByName(coordinate_field_name).castFiniteElement()
+        return get_field_values(self._detection_region, coordinate_field)
+
     def _calculate_histo_data(self):
         self._field_module.beginChange()
         field_cache = self._field_module.createFieldcache()
@@ -315,3 +321,7 @@ class AutoSegmentationModel(object):
 
     def get_output_filename(self):
         return self._output_filename
+
+    # Map methods required for Orientation and Translation handlers.
+    get_plane = get_detection_plane
+    get_plane_region = get_detection_region

--- a/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
+++ b/mapclientplugins/autosegmentationstep/model/autosegmentationmodel.py
@@ -275,6 +275,11 @@ class AutoSegmentationModel(object):
         node_set = field_module.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
         node_set.destroyAllNodes()
 
+    def reverse_visibility_field_direction(self):
+        normal = self._detection_plane.getNormal()
+        reverse_normal = [-component for component in normal]
+        self._detection_plane.setNormal(reverse_normal)
+
     def _calculate_histo_data(self):
         self._field_module.beginChange()
         field_cache = self._field_module.createFieldcache()

--- a/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
+++ b/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>646</height>
+    <height>659</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -346,6 +346,51 @@
              </property>
              <property name="checked">
               <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBoxDetectionPlane">
+          <property name="title">
+           <string>Detection Mode</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QRadioButton" name="radioButtonToggleDetection">
+             <property name="text">
+              <string>Toggle On</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Plane Alpha:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="detectionPlaneAlphaDoubleSpinBox">
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="value">
+              <double>0.400000000000000</double>
              </property>
             </widget>
            </item>

--- a/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
+++ b/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
@@ -358,22 +358,15 @@
            <string>Detection Mode</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
-           <item row="0" column="0">
-            <widget class="QRadioButton" name="radioButtonToggleDetection">
-             <property name="text">
-              <string>Toggle On</string>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_10">
+            <widget class="QCheckBox" name="checkBoxReverseField">
              <property name="text">
-              <string>Mesh Alpha</string>
+              <string>Reverse Visibility Field</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="segmentationMeshAlphaDoubleSpinBox">
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="detectionPlaneAlphaDoubleSpinBox">
              <property name="decimals">
               <number>3</number>
              </property>
@@ -388,7 +381,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="3" column="0">
             <widget class="QLabel" name="label_9">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -401,8 +394,22 @@
              </property>
             </widget>
            </item>
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="checkBoxToggleDetection">
+             <property name="text">
+              <string>Toggle On</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Mesh Alpha</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="detectionPlaneAlphaDoubleSpinBox">
+            <widget class="QDoubleSpinBox" name="segmentationMeshAlphaDoubleSpinBox">
              <property name="decimals">
               <number>3</number>
              </property>

--- a/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
+++ b/mapclientplugins/autosegmentationstep/qt/autosegmentationwidget.ui
@@ -357,15 +357,38 @@
           <property name="title">
            <string>Detection Mode</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
             <widget class="QRadioButton" name="radioButtonToggleDetection">
              <property name="text">
               <string>Toggle On</string>
              </property>
             </widget>
            </item>
-           <item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Mesh Alpha</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="segmentationMeshAlphaDoubleSpinBox">
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
             <widget class="QLabel" name="label_9">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -378,7 +401,7 @@
              </property>
             </widget>
            </item>
-           <item>
+           <item row="2" column="1">
             <widget class="QDoubleSpinBox" name="detectionPlaneAlphaDoubleSpinBox">
              <property name="decimals">
               <number>3</number>
@@ -390,7 +413,7 @@
               <double>0.010000000000000</double>
              </property>
              <property name="value">
-              <double>0.400000000000000</double>
+              <double>1.000000000000000</double>
              </property>
             </widget>
            </item>

--- a/mapclientplugins/autosegmentationstep/scene/autosegmentationscene.py
+++ b/mapclientplugins/autosegmentationstep/scene/autosegmentationscene.py
@@ -13,6 +13,8 @@ class AutoSegmentationScene(object):
         self._model = model
         self._context = model.get_context()
         self._root_scene = model.get_root_scene()
+        self._mesh_scene = model.get_mesh_scene()
+        self._detection_scene = model.get_detection_scene()
         self._output_scene = model.get_output_scene()
         self._dimensions = model.get_dimensions()
         self._output_coordinates = model.get_output_coordinates()
@@ -27,6 +29,8 @@ class AutoSegmentationScene(object):
         self._segmentation_contour.setMaterial(self._segmentation_contour_material)
         self._point_cloud = self._create_point_cloud_graphics()
         self._point_cloud.setMaterial(model.get_point_cloud_material())
+        self._segmentation_mesh = self._create_mesh_graphics()
+        self._detection_plane = self._create_detection_plane()
 
     def _create_outline_graphics(self):
         field_module = self._model.get_field_module()
@@ -96,6 +100,38 @@ class AutoSegmentationScene(object):
 
         return point_cloud
 
+    def _create_mesh_graphics(self):
+        mesh_coordinates = self._model.get_mesh_coordinates()
+
+        material_module = self._mesh_scene.getMaterialmodule()
+        green = material_module.findMaterialByName("blue")
+
+        self._mesh_scene.beginChange()
+        segmentation_mesh = self._mesh_scene.createGraphicsSurfaces()
+        segmentation_mesh.setCoordinateField(mesh_coordinates)
+        segmentation_mesh.setMaterial(green)
+        segmentation_mesh.setVisibilityFlag(True)
+        visibility_field = self._model.get_visibility_field()
+        segmentation_mesh.setSubgroupField(visibility_field)
+        self._mesh_scene.endChange()
+
+        return segmentation_mesh
+
+    def _create_detection_plane(self):
+        coordinate_field = self._model.get_detection_coordinates()
+
+        material_module = self._detection_scene.getMaterialmodule()
+        green = material_module.findMaterialByName("green")
+
+        self._detection_scene.beginChange()
+        detection_plane = self._detection_scene.createGraphicsSurfaces()
+        detection_plane.setCoordinateField(coordinate_field)
+        detection_plane.setMaterial(green)
+        detection_plane.setVisibilityFlag(False)
+        self._detection_scene.endChange()
+
+        return detection_plane
+
     def set_point_size(self, value):
         attributes = self._point_cloud.getGraphicspointattributes()
         attributes.setBaseSize(value)
@@ -114,6 +150,12 @@ class AutoSegmentationScene(object):
 
     def set_point_cloud_visibility(self, state):
         self._point_cloud.setVisibilityFlag(state != 0)
+
+    def set_mesh_visibility(self, state):
+        self._segmentation_mesh.setVisibilityFlag(state != 0)
+
+    def set_detection_plane_visibility(self, state):
+        self._detection_plane.setVisibilityFlag(state != 0)
 
     def set_slider_value(self, value):
         z_scale = self._model.get_scale()[2]

--- a/mapclientplugins/autosegmentationstep/scene/autosegmentationscene.py
+++ b/mapclientplugins/autosegmentationstep/scene/autosegmentationscene.py
@@ -30,7 +30,11 @@ class AutoSegmentationScene(object):
         self._point_cloud = self._create_point_cloud_graphics()
         self._point_cloud.setMaterial(model.get_point_cloud_material())
         self._segmentation_mesh = self._create_mesh_graphics()
+        self._segmentation_mesh_material = model.get_mesh_material()
+        self._segmentation_mesh.setMaterial(self._segmentation_mesh_material)
         self._detection_plane = self._create_detection_plane()
+        self._detection_plane_material = model.get_plane_material()
+        self._detection_plane.setMaterial(self._detection_plane_material)
 
     def _create_outline_graphics(self):
         field_module = self._model.get_field_module()
@@ -138,6 +142,12 @@ class AutoSegmentationScene(object):
 
     def set_contour_alpha(self, value):
         self._segmentation_contour_material.setAttributeReal(Material.ATTRIBUTE_ALPHA, value)
+
+    def set_mesh_alpha(self, value):
+        self._segmentation_mesh_material.setAttributeReal(Material.ATTRIBUTE_ALPHA, value)
+
+    def set_plane_alpha(self, value):
+        self._detection_plane_material.setAttributeReal(Material.ATTRIBUTE_ALPHA, value)
 
     def set_outline_visibility(self, state):
         self._outline_graphics.setVisibilityFlag(state != 0)

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -78,10 +78,21 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.segmentationAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_contour_alpha)
         self._ui.generatePointsButton.clicked.connect(self._generate_points)
         self._ui.histogramPushButton.clicked.connect(self._histogram_clicked)
+        self._ui.radioButtonToggleDetection.toggled.connect(self._toggle_detection_mode)
         self._ui.doneButton.clicked.connect(self._done_execution)
 
     def register_done_execution(self, done_execution):
         self._callback = done_execution
+
+    def _toggle_detection_mode(self, checked):
+        if checked:
+            self._model.clear_segmentation_mesh()
+            self._transform_contours_to_mesh()
+            self._generate_segmentation_mesh(self._model.get_mesh_coordinates())
+        self._scene.set_mesh_visibility(checked)
+        self._scene.set_detection_plane_visibility(checked)
+        self._scene.set_segmentation_visibility(not checked)
+        self._scene.set_point_cloud_visibility(not checked)
 
     def _settings_file(self):
         return os.path.join(self._location, 'settings.json')
@@ -93,23 +104,26 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._model.get_output_region().writeFile(self.get_output_filename())
 
     def _transform_webgl_to_exf(self):
+        root_region = self._model.get_root_region()
+        temp_region = root_region.createChild("__temp")
+        field_module = temp_region.getFieldmodule()
+        coordinate_field = create_field_coordinates(field_module)
+
+        self._generate_segmentation_mesh(coordinate_field)
+
+        temp_region.writeFile(self.get_segmentation_graphics_filename())
+        root_region.removeChild(temp_region)
+
+    def _generate_segmentation_mesh(self, coordinate_field):
         inputs = os.path.join(self._location, "ArgonSceneExporterWebGL_1.json")
         if not os.path.exists(inputs):
             return
 
-        root_region = self._model.get_root_region()
-        temp_region = root_region.createChild("__temp")
-
-        field_module = temp_region.getFieldmodule()
-        coordinate_field = create_field_coordinates(field_module)
-
+        region = coordinate_field.getFieldmodule().getRegion()
         coordinate_field_name = coordinate_field.getName()
-        import_data_into_region(temp_region, inputs, coordinate_field_name)
-
-        temp_region.writeFile(self.get_segmentation_graphics_filename())
+        import_data_into_region(region, inputs, coordinate_field_name)
 
         # Delete the WebGL JSON files.
-        root_region.removeChild(temp_region)
         os.remove(inputs)
         os.remove(os.path.join(self._location, "ArgonSceneExporterWebGL_metadata.json"))
 
@@ -117,6 +131,10 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         if not os.path.exists(self._location):
             os.makedirs(self._location)
 
+        self._transform_contours_to_mesh()
+        self._transform_webgl_to_exf()
+
+    def _transform_contours_to_mesh(self):
         # Export the scene into a WebGL JSON file.
         self._hide_graphics()
         scene = self._model.get_root_scene()
@@ -124,7 +142,6 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         scene_exporter = ArgonSceneExporter(self._location)
         scene_exporter.export_webgl_from_scene(scene, scene_filter)
         self._reinstate_graphics()
-        self._transform_webgl_to_exf()
 
     def _generate_input_hash(self):
         normalised_file_paths = [pathlib.PureWindowsPath(os.path.relpath(file_path, self._location)).as_posix()
@@ -135,12 +152,16 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._scene.set_outline_visibility(0)
         self._scene.set_image_plane_visibility(0)
         self._scene.set_point_cloud_visibility(0)
+        self._scene.set_detection_plane_visibility(0)
+        self._scene.set_mesh_visibility(0)
 
     def _reinstate_graphics(self):
         self._scene.set_outline_visibility(1 if self._ui.outlineCheckBox.isChecked() else 0)
         self._scene.set_segmentation_visibility(1 if self._ui.segmentationCheckBox.isChecked() else 0)
         self._scene.set_image_plane_visibility(1 if self._ui.imagePlaneCheckBox.isChecked() else 0)
         self._scene.set_point_cloud_visibility(1 if self._ui.pointCloudCheckBox.isChecked() else 0)
+        self._scene.set_detection_plane_visibility(1 if self._ui.radioButtonToggleDetection.isChecked() else 0)
+        self._scene.set_mesh_visibility(1 if self._ui.radioButtonToggleDetection.isChecked() else 0)
 
     def _done_execution(self):
         self._save_settings()

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -78,7 +78,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.segmentationAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_contour_alpha)
         self._ui.generatePointsButton.clicked.connect(self._generate_points)
         self._ui.histogramPushButton.clicked.connect(self._histogram_clicked)
-        self._ui.radioButtonToggleDetection.toggled.connect(self._toggle_detection_mode)
+        self._ui.checkBoxToggleDetection.stateChanged.connect(self._toggle_detection_mode)
+        self._ui.checkBoxReverseField.stateChanged.connect(self._model.reverse_visibility_field_direction)
         self._ui.segmentationMeshAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_mesh_alpha)
         self._ui.detectionPlaneAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_plane_alpha)
         self._ui.doneButton.clicked.connect(self._done_execution)
@@ -167,8 +168,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._scene.set_segmentation_visibility(1 if self._ui.segmentationCheckBox.isChecked() else 0)
         self._scene.set_image_plane_visibility(1 if self._ui.imagePlaneCheckBox.isChecked() else 0)
         self._scene.set_point_cloud_visibility(1 if self._ui.pointCloudCheckBox.isChecked() else 0)
-        self._scene.set_detection_plane_visibility(1 if self._ui.radioButtonToggleDetection.isChecked() else 0)
-        self._scene.set_mesh_visibility(1 if self._ui.radioButtonToggleDetection.isChecked() else 0)
+        self._scene.set_detection_plane_visibility(1 if self._ui.checkBoxToggleDetection.isChecked() else 0)
+        self._scene.set_mesh_visibility(1 if self._ui.checkBoxToggleDetection.isChecked() else 0)
 
     def _done_execution(self):
         self._save_settings()

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -79,6 +79,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.generatePointsButton.clicked.connect(self._generate_points)
         self._ui.histogramPushButton.clicked.connect(self._histogram_clicked)
         self._ui.radioButtonToggleDetection.toggled.connect(self._toggle_detection_mode)
+        self._ui.segmentationMeshAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_mesh_alpha)
+        self._ui.detectionPlaneAlphaDoubleSpinBox.valueChanged.connect(self._scene.set_plane_alpha)
         self._ui.doneButton.clicked.connect(self._done_execution)
 
     def register_done_execution(self, done_execution):
@@ -192,6 +194,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._ui.allowHighTessellationsCheckBox.setChecked(settings.get("tessellation-override", False))
         self._ui.overrideScalingCheckBox.setChecked(settings.get("scaling-override", False))
         self._ui.scalingLineEdit.setText(settings.get("scaling", "1, 1, 1"))
+        self._ui.segmentationMeshAlphaDoubleSpinBox.setValue(settings.get("mesh-alpha", 1.0))
+        self._ui.detectionPlaneAlphaDoubleSpinBox.setValue(settings.get("plane-alpha", 1.0))
 
         dimensions = self._model.get_dimensions()
         min_dim = min(dimensions)
@@ -228,6 +232,8 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
             "scaling": self._ui.scalingLineEdit.text(),
             "point-density": self._ui.pointDensityLineEdit.text(),
             "point-size": self._ui.pointSizeLineEdit.text(),
+            "mesh-alpha": self._ui.segmentationMeshAlphaDoubleSpinBox.value(),
+            "plane-alpha": self._ui.detectionPlaneAlphaDoubleSpinBox.value(),
         }
 
         with open(self._settings_file(), "w") as f:

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -16,6 +16,8 @@ from cmlibs.exporter.webgl import ArgonSceneExporter
 from cmlibs.importer.webgl import import_data_into_region
 from cmlibs.utils.zinc.field import create_field_coordinates
 from cmlibs.widgets.handlers.scenemanipulation import SceneManipulation
+from cmlibs.widgets.handlers.orientation import Orientation
+from cmlibs.widgets.handlers.fixedaxistranslation import FixedAxisTranslation
 
 from mapclientplugins.autosegmentationstep.model.autosegmentationmodel import AutoSegmentationModel
 from mapclientplugins.autosegmentationstep.scene.autosegmentationscene import AutoSegmentationScene
@@ -55,6 +57,14 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._view.set_context(self._model.get_context())
         self._view.register_handler(SceneManipulation())
 
+        orientation_handler = Orientation(QtCore.Qt.Key.Key_O)
+        orientation_handler.set_model(self._model)
+        self._view.register_handler(orientation_handler)
+
+        normal_handler = FixedAxisTranslation(QtCore.Qt.Key.Key_T)
+        normal_handler.set_model(self._model)
+        self._view.register_handler(normal_handler)
+
         self._setup_tessellation_line_edit()
         self._set_scale_validator()
         display_dimensions = ", ".join([f"{d}" for d in self._model.get_dimensions()])
@@ -87,6 +97,7 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
     def register_done_execution(self, done_execution):
         self._callback = done_execution
 
+    # TODO: Check if segmentation threshold has actually changed or if we can just show the same mesh.
     def _toggle_detection_mode(self, checked):
         if checked:
             self._model.clear_segmentation_mesh()

--- a/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/autosegmentationwidget.py
@@ -96,6 +96,11 @@ class AutoSegmentationWidget(QtWidgets.QWidget):
         self._scene.set_segmentation_visibility(not checked)
         self._scene.set_point_cloud_visibility(not checked)
 
+        # Enable/disable relevant UI elements.
+        self._ui.segmentationCheckBox.setEnabled(not checked)
+        self._ui.pointCloudCheckBox.setEnabled(not checked)
+        self._ui.generatePointsButton.setEnabled(not checked)
+
     def _settings_file(self):
         return os.path.join(self._location, 'settings.json')
 

--- a/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
@@ -17,9 +17,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QDoubleSpinBox, QFormLayout,
     QGridLayout, QGroupBox, QHBoxLayout, QLabel,
-    QLayout, QLineEdit, QPushButton, QRadioButton,
-    QSizePolicy, QSlider, QSpacerItem, QVBoxLayout,
-    QWidget)
+    QLayout, QLineEdit, QPushButton, QSizePolicy,
+    QSlider, QSpacerItem, QVBoxLayout, QWidget)
 
 from mapclientplugins.autosegmentationstep.widgets.zincautosegmentationwidget import ZincAutoSegmentationWidget
 
@@ -248,24 +247,19 @@ class Ui_AutoSegmentationWidget(object):
         self.groupBoxDetectionPlane.setObjectName(u"groupBoxDetectionPlane")
         self.gridLayout = QGridLayout(self.groupBoxDetectionPlane)
         self.gridLayout.setObjectName(u"gridLayout")
-        self.radioButtonToggleDetection = QRadioButton(self.groupBoxDetectionPlane)
-        self.radioButtonToggleDetection.setObjectName(u"radioButtonToggleDetection")
+        self.checkBoxReverseField = QCheckBox(self.groupBoxDetectionPlane)
+        self.checkBoxReverseField.setObjectName(u"checkBoxReverseField")
 
-        self.gridLayout.addWidget(self.radioButtonToggleDetection, 0, 0, 1, 1)
+        self.gridLayout.addWidget(self.checkBoxReverseField, 1, 0, 1, 1)
 
-        self.label_10 = QLabel(self.groupBoxDetectionPlane)
-        self.label_10.setObjectName(u"label_10")
+        self.detectionPlaneAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
+        self.detectionPlaneAlphaDoubleSpinBox.setObjectName(u"detectionPlaneAlphaDoubleSpinBox")
+        self.detectionPlaneAlphaDoubleSpinBox.setDecimals(3)
+        self.detectionPlaneAlphaDoubleSpinBox.setMaximum(1.000000000000000)
+        self.detectionPlaneAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
+        self.detectionPlaneAlphaDoubleSpinBox.setValue(1.000000000000000)
 
-        self.gridLayout.addWidget(self.label_10, 1, 0, 1, 1)
-
-        self.segmentationMeshAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
-        self.segmentationMeshAlphaDoubleSpinBox.setObjectName(u"segmentationMeshAlphaDoubleSpinBox")
-        self.segmentationMeshAlphaDoubleSpinBox.setDecimals(3)
-        self.segmentationMeshAlphaDoubleSpinBox.setMaximum(1.000000000000000)
-        self.segmentationMeshAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
-        self.segmentationMeshAlphaDoubleSpinBox.setValue(1.000000000000000)
-
-        self.gridLayout.addWidget(self.segmentationMeshAlphaDoubleSpinBox, 1, 1, 1, 1)
+        self.gridLayout.addWidget(self.detectionPlaneAlphaDoubleSpinBox, 3, 1, 1, 1)
 
         self.label_9 = QLabel(self.groupBoxDetectionPlane)
         self.label_9.setObjectName(u"label_9")
@@ -275,16 +269,26 @@ class Ui_AutoSegmentationWidget(object):
         sizePolicy3.setHeightForWidth(self.label_9.sizePolicy().hasHeightForWidth())
         self.label_9.setSizePolicy(sizePolicy3)
 
-        self.gridLayout.addWidget(self.label_9, 2, 0, 1, 1)
+        self.gridLayout.addWidget(self.label_9, 3, 0, 1, 1)
 
-        self.detectionPlaneAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
-        self.detectionPlaneAlphaDoubleSpinBox.setObjectName(u"detectionPlaneAlphaDoubleSpinBox")
-        self.detectionPlaneAlphaDoubleSpinBox.setDecimals(3)
-        self.detectionPlaneAlphaDoubleSpinBox.setMaximum(1.000000000000000)
-        self.detectionPlaneAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
-        self.detectionPlaneAlphaDoubleSpinBox.setValue(1.000000000000000)
+        self.checkBoxToggleDetection = QCheckBox(self.groupBoxDetectionPlane)
+        self.checkBoxToggleDetection.setObjectName(u"checkBoxToggleDetection")
 
-        self.gridLayout.addWidget(self.detectionPlaneAlphaDoubleSpinBox, 2, 1, 1, 1)
+        self.gridLayout.addWidget(self.checkBoxToggleDetection, 0, 0, 1, 1)
+
+        self.label_10 = QLabel(self.groupBoxDetectionPlane)
+        self.label_10.setObjectName(u"label_10")
+
+        self.gridLayout.addWidget(self.label_10, 2, 0, 1, 1)
+
+        self.segmentationMeshAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
+        self.segmentationMeshAlphaDoubleSpinBox.setObjectName(u"segmentationMeshAlphaDoubleSpinBox")
+        self.segmentationMeshAlphaDoubleSpinBox.setDecimals(3)
+        self.segmentationMeshAlphaDoubleSpinBox.setMaximum(1.000000000000000)
+        self.segmentationMeshAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
+        self.segmentationMeshAlphaDoubleSpinBox.setValue(1.000000000000000)
+
+        self.gridLayout.addWidget(self.segmentationMeshAlphaDoubleSpinBox, 2, 1, 1, 1)
 
 
         self.verticalLayout_3.addWidget(self.groupBoxDetectionPlane)
@@ -365,9 +369,10 @@ class Ui_AutoSegmentationWidget(object):
         self.pointCloudCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Point Cloud", None))
         self.outlineCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Outline", None))
         self.groupBoxDetectionPlane.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Detection Mode", None))
-        self.radioButtonToggleDetection.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Toggle On", None))
-        self.label_10.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Mesh Alpha", None))
+        self.checkBoxReverseField.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Reverse Visibility Field", None))
         self.label_9.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Plane Alpha:", None))
+        self.checkBoxToggleDetection.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Toggle On", None))
+        self.label_10.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Mesh Alpha", None))
         self.generatePointsButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Generate Points", None))
         self.histogramPushButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Show Histogram", None))
         self.doneButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"&Done", None))

--- a/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'autosegmentationwidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -17,8 +17,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QDoubleSpinBox, QFormLayout,
     QGroupBox, QHBoxLayout, QLabel, QLayout,
-    QLineEdit, QPushButton, QSizePolicy, QSlider,
-    QSpacerItem, QVBoxLayout, QWidget)
+    QLineEdit, QPushButton, QRadioButton, QSizePolicy,
+    QSlider, QSpacerItem, QVBoxLayout, QWidget)
 
 from mapclientplugins.autosegmentationstep.widgets.zincautosegmentationwidget import ZincAutoSegmentationWidget
 
@@ -26,7 +26,7 @@ class Ui_AutoSegmentationWidget(object):
     def setupUi(self, AutoSegmentationWidget):
         if not AutoSegmentationWidget.objectName():
             AutoSegmentationWidget.setObjectName(u"AutoSegmentationWidget")
-        AutoSegmentationWidget.resize(820, 646)
+        AutoSegmentationWidget.resize(820, 659)
         self.verticalLayout = QVBoxLayout(AutoSegmentationWidget)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.groupBox = QGroupBox(AutoSegmentationWidget)
@@ -243,6 +243,37 @@ class Ui_AutoSegmentationWidget(object):
 
         self.verticalLayout_3.addWidget(self.groupBoxVisibility)
 
+        self.groupBoxDetectionPlane = QGroupBox(self.groupBox)
+        self.groupBoxDetectionPlane.setObjectName(u"groupBoxDetectionPlane")
+        self.horizontalLayout_4 = QHBoxLayout(self.groupBoxDetectionPlane)
+        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.radioButtonToggleDetection = QRadioButton(self.groupBoxDetectionPlane)
+        self.radioButtonToggleDetection.setObjectName(u"radioButtonToggleDetection")
+
+        self.horizontalLayout_4.addWidget(self.radioButtonToggleDetection)
+
+        self.label_9 = QLabel(self.groupBoxDetectionPlane)
+        self.label_9.setObjectName(u"label_9")
+        sizePolicy3 = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
+        sizePolicy3.setHorizontalStretch(0)
+        sizePolicy3.setVerticalStretch(0)
+        sizePolicy3.setHeightForWidth(self.label_9.sizePolicy().hasHeightForWidth())
+        self.label_9.setSizePolicy(sizePolicy3)
+
+        self.horizontalLayout_4.addWidget(self.label_9)
+
+        self.detectionPlaneAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
+        self.detectionPlaneAlphaDoubleSpinBox.setObjectName(u"detectionPlaneAlphaDoubleSpinBox")
+        self.detectionPlaneAlphaDoubleSpinBox.setDecimals(3)
+        self.detectionPlaneAlphaDoubleSpinBox.setMaximum(1.000000000000000)
+        self.detectionPlaneAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
+        self.detectionPlaneAlphaDoubleSpinBox.setValue(0.400000000000000)
+
+        self.horizontalLayout_4.addWidget(self.detectionPlaneAlphaDoubleSpinBox)
+
+
+        self.verticalLayout_3.addWidget(self.groupBoxDetectionPlane)
+
 
         self.horizontalLayout_3.addLayout(self.verticalLayout_3)
 
@@ -252,11 +283,11 @@ class Ui_AutoSegmentationWidget(object):
 
         self.zincWidget = ZincAutoSegmentationWidget(self.groupBox)
         self.zincWidget.setObjectName(u"zincWidget")
-        sizePolicy3 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        sizePolicy3.setHorizontalStretch(1)
-        sizePolicy3.setVerticalStretch(1)
-        sizePolicy3.setHeightForWidth(self.zincWidget.sizePolicy().hasHeightForWidth())
-        self.zincWidget.setSizePolicy(sizePolicy3)
+        sizePolicy4 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sizePolicy4.setHorizontalStretch(1)
+        sizePolicy4.setVerticalStretch(1)
+        sizePolicy4.setHeightForWidth(self.zincWidget.sizePolicy().hasHeightForWidth())
+        self.zincWidget.setSizePolicy(sizePolicy4)
 
         self.horizontalLayout_3.addWidget(self.zincWidget)
 
@@ -318,6 +349,9 @@ class Ui_AutoSegmentationWidget(object):
         self.segmentationCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Segmentation", None))
         self.pointCloudCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Point Cloud", None))
         self.outlineCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Outline", None))
+        self.groupBoxDetectionPlane.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Detection Mode", None))
+        self.radioButtonToggleDetection.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Toggle On", None))
+        self.label_9.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Plane Alpha:", None))
         self.generatePointsButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Generate Points", None))
         self.histogramPushButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Show Histogram", None))
         self.doneButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"&Done", None))

--- a/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
+++ b/mapclientplugins/autosegmentationstep/widgets/ui_autosegmentationwidget.py
@@ -16,9 +16,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QDoubleSpinBox, QFormLayout,
-    QGroupBox, QHBoxLayout, QLabel, QLayout,
-    QLineEdit, QPushButton, QRadioButton, QSizePolicy,
-    QSlider, QSpacerItem, QVBoxLayout, QWidget)
+    QGridLayout, QGroupBox, QHBoxLayout, QLabel,
+    QLayout, QLineEdit, QPushButton, QRadioButton,
+    QSizePolicy, QSlider, QSpacerItem, QVBoxLayout,
+    QWidget)
 
 from mapclientplugins.autosegmentationstep.widgets.zincautosegmentationwidget import ZincAutoSegmentationWidget
 
@@ -245,12 +246,26 @@ class Ui_AutoSegmentationWidget(object):
 
         self.groupBoxDetectionPlane = QGroupBox(self.groupBox)
         self.groupBoxDetectionPlane.setObjectName(u"groupBoxDetectionPlane")
-        self.horizontalLayout_4 = QHBoxLayout(self.groupBoxDetectionPlane)
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.gridLayout = QGridLayout(self.groupBoxDetectionPlane)
+        self.gridLayout.setObjectName(u"gridLayout")
         self.radioButtonToggleDetection = QRadioButton(self.groupBoxDetectionPlane)
         self.radioButtonToggleDetection.setObjectName(u"radioButtonToggleDetection")
 
-        self.horizontalLayout_4.addWidget(self.radioButtonToggleDetection)
+        self.gridLayout.addWidget(self.radioButtonToggleDetection, 0, 0, 1, 1)
+
+        self.label_10 = QLabel(self.groupBoxDetectionPlane)
+        self.label_10.setObjectName(u"label_10")
+
+        self.gridLayout.addWidget(self.label_10, 1, 0, 1, 1)
+
+        self.segmentationMeshAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
+        self.segmentationMeshAlphaDoubleSpinBox.setObjectName(u"segmentationMeshAlphaDoubleSpinBox")
+        self.segmentationMeshAlphaDoubleSpinBox.setDecimals(3)
+        self.segmentationMeshAlphaDoubleSpinBox.setMaximum(1.000000000000000)
+        self.segmentationMeshAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
+        self.segmentationMeshAlphaDoubleSpinBox.setValue(1.000000000000000)
+
+        self.gridLayout.addWidget(self.segmentationMeshAlphaDoubleSpinBox, 1, 1, 1, 1)
 
         self.label_9 = QLabel(self.groupBoxDetectionPlane)
         self.label_9.setObjectName(u"label_9")
@@ -260,16 +275,16 @@ class Ui_AutoSegmentationWidget(object):
         sizePolicy3.setHeightForWidth(self.label_9.sizePolicy().hasHeightForWidth())
         self.label_9.setSizePolicy(sizePolicy3)
 
-        self.horizontalLayout_4.addWidget(self.label_9)
+        self.gridLayout.addWidget(self.label_9, 2, 0, 1, 1)
 
         self.detectionPlaneAlphaDoubleSpinBox = QDoubleSpinBox(self.groupBoxDetectionPlane)
         self.detectionPlaneAlphaDoubleSpinBox.setObjectName(u"detectionPlaneAlphaDoubleSpinBox")
         self.detectionPlaneAlphaDoubleSpinBox.setDecimals(3)
         self.detectionPlaneAlphaDoubleSpinBox.setMaximum(1.000000000000000)
         self.detectionPlaneAlphaDoubleSpinBox.setSingleStep(0.010000000000000)
-        self.detectionPlaneAlphaDoubleSpinBox.setValue(0.400000000000000)
+        self.detectionPlaneAlphaDoubleSpinBox.setValue(1.000000000000000)
 
-        self.horizontalLayout_4.addWidget(self.detectionPlaneAlphaDoubleSpinBox)
+        self.gridLayout.addWidget(self.detectionPlaneAlphaDoubleSpinBox, 2, 1, 1, 1)
 
 
         self.verticalLayout_3.addWidget(self.groupBoxDetectionPlane)
@@ -351,6 +366,7 @@ class Ui_AutoSegmentationWidget(object):
         self.outlineCheckBox.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Outline", None))
         self.groupBoxDetectionPlane.setTitle(QCoreApplication.translate("AutoSegmentationWidget", u"Detection Mode", None))
         self.radioButtonToggleDetection.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Toggle On", None))
+        self.label_10.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Mesh Alpha", None))
         self.label_9.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Plane Alpha:", None))
         self.generatePointsButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Generate Points", None))
         self.histogramPushButton.setText(QCoreApplication.translate("AutoSegmentationWidget", u"Show Histogram", None))


### PR DESCRIPTION
This PR adds a detection mode to the plugin UI. While detection mode is active, the user has control over a visibility plane which can show/hide certain sections of the segmentation mesh. This is intended to aid the user in determining the ideal segmentation contour threshold.

Currently, while in detection mode, the visibility plane can by rotated while holding the _O_ key, and translated while holding the _T_ key.